### PR TITLE
Allow using external secret

### DIFF
--- a/helm/k8s-agent/templates/deployment.yaml
+++ b/helm/k8s-agent/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           - name: AGENT_TOKEN
             valueFrom:
               secretKeyRef:
-                name: k8s-agent-token-secret
+                name: {{ .Values.secret.name }}
                 key: agentToken
           - name: CLUSTER_NAME
             value: {{ required "K8s cluster name is required" .Values.general.clusterName }}

--- a/helm/k8s-agent/templates/secret.yaml
+++ b/helm/k8s-agent/templates/secret.yaml
@@ -1,7 +1,9 @@
+{{ if .Values.secret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: k8s-agent-token-secret
+  name: {{ .Values.secret.name }}
 type: Opaque
 data:
   agentToken: {{ required "A valid CloudXray K8s agent token is required" .Values.general.agentToken | b64enc | quote }}
+{{- end }}

--- a/helm/k8s-agent/values.yaml
+++ b/helm/k8s-agent/values.yaml
@@ -23,6 +23,13 @@ podLabels: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
+secret:
+  # -- Whether helm chart creates controller secret
+  create: true
+
+  # -- Override to use your own secret
+  name: "k8s-agent-token-secret"
+
 securityContext: {}
   # capabilities:
   #   drop:


### PR DESCRIPTION
Rather than creating a secret, allow users to pass in an existing secret. This is useful for users who have secrets automatically created by the Vault Secrets Operator.